### PR TITLE
refactor(src): refactor regex to blacklist all numbers or letters

### DIFF
--- a/src/passwordcheck.js
+++ b/src/passwordcheck.js
@@ -27,12 +27,26 @@ define([
       PASSWORD_TOO_SHORT: 'PASSWORD_TOO_SHORT'
     };
 
+    function isAllLetters(password) {
+      return /^[a-zA-Z]+$/.test(password);
+    }
+
+    function isAllNumbers(password) {
+      return /^[0-9]+$/.test(password);
+    }
+
     function isWeakPassword(password) {
       // Check for passwords that consist of only numbers
       // or only alphabets, and are of length less than (minlength + 4)
-      var regexString = '([a-zA-Z]){' + minLength + ',' + (minLength + 4) + '}|([0-9]){' + minLength + ',' + (minLength + 4) + '}';
-      var regex = new RegExp(regexString);
-      return regex.test(password);
+      if (password.length >= (minLength + 4)) {
+        return false;
+      } else if (isAllLetters(password)) {
+        return true;
+      } else if (isAllNumbers(password)) {
+        return true;
+      }
+
+      return false;
     }
 
     return function (password, callback) {

--- a/src/passwordcheck.js
+++ b/src/passwordcheck.js
@@ -27,10 +27,10 @@ define([
       PASSWORD_TOO_SHORT: 'PASSWORD_TOO_SHORT'
     };
 
-    function isStrongEnough(password) {
-      // Check for passwords that at least contain a number and an alphabet,
-      // or if alphabets, then at least (minLength + 4) characters long
-      var regexString = '((?=.*[a-zA-Z])(?=.*[0-9])[A-Za-z0-9!@#$%^&*()_+ ]{' + minLength + ',' + (minLength + 4) + '})|([A-Za-z0-9!@#$%^&*()_+ ]{' + (minLength + 4) + ',})';
+    function isWeakPassword(password) {
+      // Check for passwords that consist of only numbers
+      // or only alphabets, and are of length less than (minlength + 4)
+      var regexString = '([a-zA-Z]){' + minLength + ',' + (minLength + 4) + '}|([0-9]){' + minLength + ',' + (minLength + 4) + '}';
       var regex = new RegExp(regexString);
       return regex.test(password);
     }
@@ -45,7 +45,7 @@ define([
       // password is non-empty, a string and length greater
       // than minimum length we can start checking
       // for password strength
-      } else if (! isStrongEnough(password)) {
+      } else if (isWeakPassword(password)) {
         callback(MESSAGES.NOT_STRONG_ENOUGH);
       // Only if the password has a chance of being
       // strong do we check with the bloom filter

--- a/tests/password_checker_test.js
+++ b/tests/password_checker_test.js
@@ -41,7 +41,7 @@ define(['chai', 'passwordcheck'], function (chai, PasswordCheck) {
       var badPasswords = ['hooters1', 'charlie2', '!ILO9VEYOU', 'hate_you1990'];
       badPasswords.forEach(function (password) {
         passwordcheck(password, function (res) {
-          assert.equal('BLOOMFILTER_HIT', res);
+          assert.equal('BLOOMFILTER_HIT', res, password);
         });
       });
     });
@@ -50,7 +50,7 @@ define(['chai', 'passwordcheck'], function (chai, PasswordCheck) {
       var goodPasswords = ['notinyourdictionary!', 'imaynotbetheretoo', 'thisisagoodcleanpassword', 'combo1234$#@'];
       goodPasswords.forEach(function (password) {
         passwordcheck(password, function (res) {
-          assert.equal('BLOOMFILTER_MISS', res);
+          assert.equal('BLOOMFILTER_MISS', res, password);
         });
       });
     });

--- a/tests/password_checker_test.js
+++ b/tests/password_checker_test.js
@@ -26,7 +26,7 @@ define(['chai', 'passwordcheck'], function (chai, PasswordCheck) {
     });
 
     it('returns NOT_STRONG_ENOUGH when password is all numbers', function () {
-      passwordcheck('12456789', function (res) {
+      passwordcheck('124567890', function (res) {
         assert.equal('NOT_STRONG_ENOUGH', res);
       });
     });


### PR DESCRIPTION
refactor the regex to simplify usage, and to blacklist bad passwords instead of whitelisting strong passwords.
@shane-tomlinson 
PS: Im sorry for all the merge-commit-messages, I dont know how to remove them :(
