### PR TITLE
chore(tests): run tests from the cli, via phantomjs

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   "scripts": {
     "setup": "npm install && bower install",
     "build": "grunt build",
-    "test": "grunt lint",
+    "test": "grunt mocha",
     "lint": "grunt lint"
   },
   "repository": {
@@ -34,6 +34,7 @@
     "eslint-config-fxa": "1.8.1",
     "grunt": "0.4.5",
     "grunt-eslint": "16.0.0",
+    "grunt-mocha": "0.4.15",
     "grunt-requirejs": "0.4.2",
     "load-grunt-tasks": "3.2.0",
     "requirejs": "2.1.20"

--- a/tasks/mocha.js
+++ b/tasks/mocha.js
@@ -1,0 +1,13 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+module.exports = function (grunt) {
+  'use strict';
+  grunt.config('mocha', {
+    test: {
+      src: ['tests/**/*.html']
+    }
+  });
+  grunt.loadNpmTasks('grunt-mocha');
+};

--- a/tests/index.html
+++ b/tests/index.html
@@ -28,11 +28,7 @@
   require([
     './password_checker_test'
   ], function () {
-    if (window.mochaPhantomJS) {
-      mochaPhantomJS.run();
-    } else {
-      mocha.run();
-    }
+    mocha.run();
   });
 </script>
 </body>


### PR DESCRIPTION
fixes #13 .  Uses `grunt-mocha`, which invokes phantomjs.  Runnable on the CLI using `npm test`
